### PR TITLE
Refactor: Improve logging and Monitor performance

### DIFF
--- a/src/main/java/com/tinyjvm/threads/JVMThread.java
+++ b/src/main/java/com/tinyjvm/threads/JVMThread.java
@@ -1,5 +1,6 @@
 package com.tinyjvm.threads;
 
+import com.tinyjvm.utils.Logger;
 import com.tinyjvm.interpreter.BytecodeInterpreter;
 import com.tinyjvm.interpreter.JVMHeap; // Required for interpreter instantiation
 import com.tinyjvm.interpreter.JVMStack;
@@ -32,7 +33,7 @@ public class JVMThread {
             // This is a temporary measure. Heap should be properly initialized and passed.
             // throw new IllegalStateException("Shared JVMHeap instance not set for JVMThread constructor.");
             // For now, allow it to be null if tests don't immediately use opcodes needing heap.
-            System.err.println("Warning: JVMThread created but sharedHeapInstance is null. Interpreter might fail for heap operations.");
+            Logger.error("Warning: JVMThread created but sharedHeapInstance is null. Interpreter might fail for heap operations.");
         }
         this.interpreter = new BytecodeInterpreter(sharedHeapInstance);
     }
@@ -43,7 +44,7 @@ public class JVMThread {
             throw new IllegalThreadStateException("Thread has already been started.");
         }
         state = ThreadState.RUNNABLE;
-        System.out.println("Thread " + threadId + " state set to RUNNABLE. Target: " + (target != null ? target.getClass().getName() : "null"));
+        Logger.info("Thread " + threadId + " state set to RUNNABLE. Target: " + (target != null ? target.getClass().getName() : "null"));
         Scheduler.getInstance().registerThread(this); // Now we can uncomment this
     }
 
@@ -53,18 +54,18 @@ public class JVMThread {
             // this can happen. Only execute if truly RUNNING.
             // Or, the scheduler should ensure it only calls on RUNNING threads.
             // For now, let's be defensive.
-            // System.out.println("Thread " + threadId + " executeNextInstruction called when not RUNNING. State: " + state);
+            Logger.debug("Thread " + threadId + " executeNextInstruction called when not RUNNING. State: " + state);
             return state == ThreadState.RUNNABLE; // If runnable, it's okay, scheduler will handle. If other, it's an issue.
         }
 
         // Initial execution of target.run() if stack is empty
         if (stack.isEmpty()) {
             if (target != null) {
-                System.out.println("Thread " + threadId + " [State:" + state + "]: Executing target.run() for the first time.");
+                Logger.debug("Thread " + threadId + " [State:" + state + "]: Executing target.run() for the first time.");
                 try {
                     target.run(); // This might push frames and set up for bytecode execution
                 } catch (Exception e) {
-                    System.err.println("Thread " + threadId + " threw an exception in target.run(): " + e.getMessage());
+                    Logger.error("Thread " + threadId + " threw an exception in target.run(): " + e.getMessage());
                     state = ThreadState.TERMINATED;
                     return false;
                 }
@@ -72,13 +73,13 @@ public class JVMThread {
                 if (stack.isEmpty()) {
                     // If target.run() was self-contained and didn't push frames for bytecode.
                     state = ThreadState.TERMINATED;
-                    System.out.println("Thread " + threadId + " [State:" + state + "]: Terminated (target.run() completed and no new frames pushed).");
+                    Logger.info("Thread " + threadId + " [State:" + state + "]: Terminated (target.run() completed and no new frames pushed).");
                     return false;
                 }
                 // If frames were pushed, execution will proceed to interpreter below.
             } else {
                 state = ThreadState.TERMINATED;
-                System.out.println("Thread " + threadId + " [State:" + state + "]: Terminated (no target and stack empty).");
+                Logger.info("Thread " + threadId + " [State:" + state + "]: Terminated (no target and stack empty).");
                 return false;
             }
         }

--- a/src/main/java/com/tinyjvm/utils/Logger.java
+++ b/src/main/java/com/tinyjvm/utils/Logger.java
@@ -1,0 +1,35 @@
+package com.tinyjvm.utils;
+
+public class Logger {
+
+    public enum LogLevel {
+        DEBUG,
+        INFO,
+        ERROR,
+        NONE
+    }
+
+    private static LogLevel currentLevel = LogLevel.INFO;
+
+    public static void setLevel(LogLevel level) {
+        currentLevel = level;
+    }
+
+    public static void debug(String message) {
+        if (currentLevel.ordinal() <= LogLevel.DEBUG.ordinal()) {
+            System.out.println("[DEBUG] " + message);
+        }
+    }
+
+    public static void info(String message) {
+        if (currentLevel.ordinal() <= LogLevel.INFO.ordinal()) {
+            System.out.println("[INFO] " + message);
+        }
+    }
+
+    public static void error(String message) {
+        if (currentLevel.ordinal() <= LogLevel.ERROR.ordinal()) {
+            System.err.println("[ERROR] " + message);
+        }
+    }
+}


### PR DESCRIPTION
This commit introduces several changes:

1.  **Basic Logging Facade:**
    - Implemented a simple `com.tinyjvm.utils.Logger` with configurable levels (DEBUG, INFO, ERROR, NONE).
    - Replaced `System.out.println` and `System.err.println` across `JVMThread`, `Scheduler`, and `Monitor` classes with the new logger. This reduces console noise by default (INFO level) and allows for detailed debugging when needed (DEBUG level), addressing performance concerns related to excessive logging in hot paths.

2.  **Monitor Performance Optimization:**
    - Optimized the `Monitor.enter()` method to use a `HashSet` (`waitingThreads`) for O(1) checking if a thread is already waiting for the monitor.
    - The existing `LinkedList` (`entryQueue`) is still used to maintain the order of waiting threads for fairness.
    - This addresses the O(n) `entryQueue.contains(thread)` call, which could be costly under high contention.

3.  **General Refinements:**
    - Code now uses the logger for different levels of information, making it easier to debug and understand the system's behavior without overwhelming console output.

These changes improve the performance and maintainability of the threading subsystem.